### PR TITLE
Make reload bar animate with CSS

### DIFF
--- a/static/client.js
+++ b/static/client.js
@@ -57,15 +57,8 @@ document.getElementById("option-b").addEventListener("click", async() => {
 
 
 function transitionToNext() {
-	let width = 0;
-
-	const interval = setInterval(() => {
-		width += 0.5;
-		document.getElementById("progressbar").style.width = width + "vw";
-		if (width >= 100) {
-			location.reload();
-		}
-	}, 20);
+	document.getElementById("progressbar").style.width = "100vw";
+	setTimeout(()=>location.reload(), 5000);
 }
 
 

--- a/static/main.css
+++ b/static/main.css
@@ -64,7 +64,7 @@ p {
 	position: fixed;
 	left: -4px;
 	top: 0;
-	height: 2px;
+	height: 6px;
 	width: 0%;
 	padding: 2px;
 	background-color: #37e;
@@ -123,7 +123,7 @@ p {
 		max-width: initial;
 		max-height: calc( 100% - 150px );
 	}
-	.header h1 {
+	h1 {
 		margin-bottom: 6px;
 	}
 }

--- a/static/main.css
+++ b/static/main.css
@@ -62,11 +62,14 @@ p {
 
 #progressbar {
 	position: fixed;
-	left: 0;
+	left: -4px;
 	top: 0;
-	height: 10px;
+	height: 2px;
 	width: 0%;
+	padding: 2px;
 	background-color: #37e;
+	border-radius: 2px;
+	transition: linear 5s;
 }
 
 #newbutton, #leaderlink, #mainlink {
@@ -119,6 +122,9 @@ p {
 	.flag {
 		max-width: initial;
 		max-height: calc( 100% - 150px );
+	}
+	.header h1 {
+		margin-bottom: 6px;
 	}
 }
 


### PR DESCRIPTION
Made the reload bar animation happen in CSS instead of by manually updating the width in JS. Also improved its appearance and made the mobile layout more compact.